### PR TITLE
feat(luckymon): support links and update display names for variants & forms

### DIFF
--- a/src/commands/luckymon.rs
+++ b/src/commands/luckymon.rs
@@ -37,13 +37,51 @@ async fn read_daily_entry(ctx: &Context, user_id: UserId) -> Option<(i64, bool)>
     entry
 }
 
+// Function that returns a boolean value
+fn is_divisible_by(lhs: u32, rhs: u32) -> bool {
+    // Corner case, early return
+    if rhs == 0 {
+        return false;
+    }
+
+    // This is an expression, the `return` keyword is not necessary here
+    lhs % rhs == 0
+}
+
+fn format_for_display(name: &str) -> &str {
+    if name.contains("-") {
+        if name.contains("idoran") {
+            if name.contains("-f") {
+                return "Nidoran\\♀";
+            } else {
+                return "Nidoran\\♂";
+            }
+        }
+    }
+    return name;
+}
+
+fn format_for_bulba(name: &str) -> &str {
+    if name.contains("-") {
+        if name.contains("idoran") {
+            if name.contains("-f") {
+                return "Nidoran%E2%99%80";
+            } else {
+                return "Nidoran%E2%99%82";
+            }
+        }
+        return "fuck!";
+    }
+    return name;
+}
+
 #[command]
 #[description = "Lucky pokemon of the day!"]
 async fn luckymon(ctx: &Context, msg: &Message) -> CommandResult {
     println!("Got luckymon command..");
     let user_id = msg.author.id;
 
-    let lucky_num = fastrand::i64(1..=905);
+    let lucky_num = 642; //fastrand::i64(1..=905);
     let shiny_num = fastrand::i64(1..=500);
     let mut is_shiny = false;
     if shiny_num == 1 {
@@ -64,8 +102,10 @@ async fn luckymon(ctx: &Context, msg: &Message) -> CommandResult {
     let rustemon_client = RustemonClient::default();
     let lucky_pokemon: Pokemon = pokemon::get_by_id(daily_pair.0, &rustemon_client).await?;
 
-    let regular_name = lucky_pokemon.name[0..1].to_uppercase() + &lucky_pokemon.name[1..];
-    let mut final_name = String::from(&regular_name);
+    let regular_name = lucky_pokemon.species.name[0..1].to_uppercase() + &lucky_pokemon.species.name[1..];
+    let display_name = format_for_display(&regular_name);
+    let mut final_name = String::from(display_name);
+    let link_name: &str = format_for_bulba(&regular_name);
     let regular_sprite = lucky_pokemon.sprites.front_default.unwrap();
     let shiny_sprite = lucky_pokemon.sprites.front_shiny.unwrap();
     let mut sprite = regular_sprite;
@@ -80,7 +120,7 @@ async fn luckymon(ctx: &Context, msg: &Message) -> CommandResult {
             m.embed(|e| {
                 e.title("Your lucky pokemon of the day is:")
                     .image(sprite)
-                    .fields(vec!((format!("{}!", &final_name), format!("[Bulbapedia Page](https://bulbapedia.bulbagarden.net/wiki/{}_(Pok%C3%A9mon))", regular_name).to_string(), false)))
+                    .fields(vec!((format!("{}!", &final_name), format!("[Bulbapedia Page](https://bulbapedia.bulbagarden.net/wiki/{}_(Pok%C3%A9mon))", link_name).to_string(), false)))
                     .timestamp(Timestamp::now())
             })
         })

--- a/src/commands/luckymon.rs
+++ b/src/commands/luckymon.rs
@@ -48,31 +48,70 @@ fn is_divisible_by(lhs: u32, rhs: u32) -> bool {
     lhs % rhs == 0
 }
 
-fn format_for_display(name: &str) -> &str {
-    if name.contains("-") {
-        if name.contains("idoran") {
-            if name.contains("-f") {
-                return "Nidoran\\♀";
-            } else {
-                return "Nidoran\\♂";
-            }
-        }
-    }
-    return name;
+fn capitalize(name: &str) -> String {
+    let (n1, n2) = name.split_at(1);
+    let n_upper = n1.to_uppercase();
+    let new_name = n_upper + n2;
+    return new_name.to_string();
 }
 
-fn format_for_bulba(name: &str) -> &str {
-    if name.contains("-") {
-        if name.contains("idoran") {
+fn capitalize_hyphenated(name: &str, keep_hyphen: bool) -> String {
+    let hyphen_index = name.chars().position(|c| c == '-').unwrap();
+    let (n1, eh) = name.split_at(hyphen_index);
+    let (_uh, n2) = eh.split_at(1);
+    let middle_char = if keep_hyphen { "-" } else { " " };
+    let new_name = capitalize(n1) + middle_char + &capitalize(n2);
+    return new_name.to_string();
+}
+
+
+fn has_hyphen(name: &str) -> bool {
+    return name.contains("-");
+}
+
+fn is_nidoran(name: &str) -> bool {
+    return name.contains("idoran");
+}
+
+
+fn format_for_display(name: &str) -> String {
+    if has_hyphen(name) {
+        if is_nidoran(name) {
+            // nidoran male and female need special display
             if name.contains("-f") {
-                return "Nidoran%E2%99%80";
+                return "Nidoran \\♀".to_string();
             } else {
-                return "Nidoran%E2%99%82";
+                return "Nidoran \\♂".to_string();
             }
         }
-        return "fuck!";
+
+        if name.contains("-oh") || name.contains("-z") {
+            return capitalize_hyphenated(name, true);
+        }
+
+        // other stuff falls thru and removes the hyphen, like Thundurus-incarnate -> Thundurus Incarnate
+        return capitalize_hyphenated(name, false);
     }
-    return name;
+    return capitalize(name).to_string();
+}
+
+
+fn format_for_bulba(name: &str) -> String {
+    if has_hyphen(name) {
+        // nidoran male and female need encoding
+        if is_nidoran(name) {
+            if name.contains("-f") {
+                return "Nidoran%E2%99%80".to_string();
+            } else {
+                return "Nidoran%E2%99%82".to_string();
+            }
+        }
+
+        if name.contains("-oh") || name.contains("-z") {
+            return capitalize_hyphenated(name, true);
+        }
+    }
+    return capitalize(name).to_string();
 }
 
 #[command]
@@ -81,7 +120,7 @@ async fn luckymon(ctx: &Context, msg: &Message) -> CommandResult {
     println!("Got luckymon command..");
     let user_id = msg.author.id;
 
-    let lucky_num = 642; //fastrand::i64(1..=905);
+    let lucky_num = 29; //fastrand::i64(1..=905);
     let shiny_num = fastrand::i64(1..=500);
     let mut is_shiny = false;
     if shiny_num == 1 {
@@ -102,16 +141,16 @@ async fn luckymon(ctx: &Context, msg: &Message) -> CommandResult {
     let rustemon_client = RustemonClient::default();
     let lucky_pokemon: Pokemon = pokemon::get_by_id(daily_pair.0, &rustemon_client).await?;
 
-    let regular_name = lucky_pokemon.species.name[0..1].to_uppercase() + &lucky_pokemon.species.name[1..];
+    let regular_name = lucky_pokemon.species.name;
     let display_name = format_for_display(&regular_name);
     let mut final_name = String::from(display_name);
-    let link_name: &str = format_for_bulba(&regular_name);
+    let link_name = format_for_bulba(&regular_name);
     let regular_sprite = lucky_pokemon.sprites.front_default.unwrap();
-    let shiny_sprite = lucky_pokemon.sprites.front_shiny.unwrap();
+
     let mut sprite = regular_sprite;
     if daily_pair.1 {
         final_name = format!("Shiny {}", regular_name);
-        sprite = shiny_sprite;
+        sprite = lucky_pokemon.sprites.front_shiny.unwrap()
     }
 
     let _msg = msg

--- a/src/commands/luckymon.rs
+++ b/src/commands/luckymon.rs
@@ -78,7 +78,7 @@ fn format_for_display(name: &str) -> String {
             return capitalize_hyphenated(name, true);
         }
 
-        // other stuff falls thru and removes the hyphen, like Thundurus-incarnate -> Thundurus Incarnate
+        // other stuff falls thru and removes the hyphen
         return capitalize_hyphenated(name, false);
     }
     return capitalize(name).to_string();

--- a/src/commands/luckymon.rs
+++ b/src/commands/luckymon.rs
@@ -37,17 +37,6 @@ async fn read_daily_entry(ctx: &Context, user_id: UserId) -> Option<(i64, bool)>
     entry
 }
 
-// Function that returns a boolean value
-fn is_divisible_by(lhs: u32, rhs: u32) -> bool {
-    // Corner case, early return
-    if rhs == 0 {
-        return false;
-    }
-
-    // This is an expression, the `return` keyword is not necessary here
-    lhs % rhs == 0
-}
-
 fn capitalize(name: &str) -> String {
     let (n1, n2) = name.split_at(1);
     let n_upper = n1.to_uppercase();
@@ -70,7 +59,7 @@ fn has_hyphen(name: &str) -> bool {
 }
 
 fn is_nidoran(name: &str) -> bool {
-    return name.contains("idoran");
+    return name.contains("idoran"); // sorry lol
 }
 
 
@@ -120,7 +109,7 @@ async fn luckymon(ctx: &Context, msg: &Message) -> CommandResult {
     println!("Got luckymon command..");
     let user_id = msg.author.id;
 
-    let lucky_num = 29; //fastrand::i64(1..=905);
+    let lucky_num = fastrand::i64(1..=905);
     let shiny_num = fastrand::i64(1..=500);
     let mut is_shiny = false;
     if shiny_num == 1 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ impl EventHandler for Handler {}
 #[tokio::main]
 async fn main() {
     let framework = StandardFramework::new()
-        .configure(|c| c.prefix(".")) // set the bot's prefix to "."
+        .configure(|c| c.prefix("k")) // set the bot's prefix to "."
         .group(&GENERAL_GROUP)
         .group(&ADMIN_GROUP)
         .help(&HELP);

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ impl EventHandler for Handler {}
 #[tokio::main]
 async fn main() {
     let framework = StandardFramework::new()
-        .configure(|c| c.prefix("k")) // set the bot's prefix to "."
+        .configure(|c| c.prefix(".")) // set the bot's prefix to "."
         .group(&GENERAL_GROUP)
         .group(&ADMIN_GROUP)
         .help(&HELP);


### PR DESCRIPTION
Please let me know if I should move anything out into other files, follow your standards more closely, or can otherwise improve! :)

Pokemon such as Thundurus, who shows up as thundurus-incarnate, and Nidoran♀, who shows up as nidoran-f, are now handled both for linking and display names!  Other special cases include Porygon-Z and Ho-Oh.